### PR TITLE
Add the ability to toggle whether to show mark class text

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -43,6 +43,7 @@ std::atomic<bool> exit_flag(false);
 
 std::atomic<int> mark_line_width(2); // default mark line width is 2 pixels.
 const int MAX_MARK_LINE_WIDTH = 3;
+std::atomic<bool> show_mark_class(true);
 
 std::atomic<int> x_start, y_start;
 std::atomic<int> x_end, y_end;
@@ -558,8 +559,11 @@ int main(int argc, char *argv[])
 						Point2i(max(x_start, x_end), max(y_start, y_end)));
 					rectangle(frame, selected_rect, Scalar(150, 200, 150));
 
-					putText(frame, std::to_string(current_obj_id) + current_synset_name,
-						selected_rect.tl() + Point2i(2, 22), FONT_HERSHEY_SIMPLEX, 0.8, Scalar(150, 200, 150), 2);
+					if (show_mark_class)
+					{
+						putText(frame, std::to_string(current_obj_id) + current_synset_name,
+							selected_rect.tl() + Point2i(2, 22), FONT_HERSHEY_SIMPLEX, 0.8, Scalar(150, 200, 150), 2);
+					}
 				}
 			}
 
@@ -605,8 +609,12 @@ int main(int argc, char *argv[])
 				int blue = (offset + 140) % 255 * ((i.id + 0) % 3);
 				Scalar color_rect(red, green, blue);    // Scalar color_rect(100, 200, 100);
 
-				putText(full_image_roi, std::to_string(i.id) + synset_name,
-					i.abs_rect.tl() + Point2f(2, 22), FONT_HERSHEY_SIMPLEX, 0.8, color_rect, mark_line_width);
+				if (show_mark_class)
+				{
+					putText(full_image_roi, std::to_string(i.id) + synset_name,
+						i.abs_rect.tl() + Point2f(2, 22), FONT_HERSHEY_SIMPLEX, 0.8, color_rect, 2);
+				}
+
 				rectangle(full_image_roi, i.abs_rect, color_rect, mark_line_width);
 			}
 
@@ -723,6 +731,9 @@ int main(int argc, char *argv[])
 			case 1048680:	// h
 				show_help = !show_help;
 			break;
+			case 'k':
+				show_mark_class = !show_mark_class;
+				break;
 			default:
 				;
 			}


### PR DESCRIPTION
When marking elements which are close together the name of the class might cover parts of the image required to be selected.
By allowing the user to hide the mark class text it helps marking the elements.